### PR TITLE
Not using date objects, but fixed strings with day and month r=@wilsonpage

### DIFF
--- a/lib/sched.js
+++ b/lib/sched.js
@@ -109,7 +109,7 @@ function formatTime(string) {
   const components = string.split('-');
   const month = months[parseInt(components[1]) -1];
   const day = components[2];
-  return `${month}, ${day}`;
+  return `${day} ${month}`;
 }
 
 const SchedModule = {

--- a/lib/sched.js
+++ b/lib/sched.js
@@ -104,12 +104,12 @@ Venue.prototype.parseLight = function() {
 };
 
 function formatTime(string) {
-console.log(string);
-  var days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   var months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
 
-  var date = new Date(string);
-  return `${days[date.getDay()]} ${date.getDate()} ${months[date.getMonth()]}`;
+  const components = string.split('-');
+  const month = months[parseInt(components[1]) -1];
+  const day = components[2];
+  return `${month}, ${day}`;
 }
 
 const SchedModule = {


### PR DESCRIPTION
We were getting a date without time nor tz.

Instead of playing the crazy game of going after the user's tz and rendering in the client. Just got the data coming from sched day and month and that's what we render.

r= @wilsonpage ?
